### PR TITLE
Add 'play --playlist' support. Issue #27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/brianstrauch/spotify v0.6.0
+	github.com/brianstrauch/spotify v0.7.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
 	github.com/rhysd/go-github-selfupdate v1.2.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/brianstrauch/spotify v0.5.0
+	github.com/brianstrauch/spotify v0.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
 	github.com/rhysd/go-github-selfupdate v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/brianstrauch/spotify v0.5.0 h1:IUEY5JPEPJJJdyVdpcH8ZzviGxI3Ra3huWPN+517MbU=
 github.com/brianstrauch/spotify v0.5.0/go.mod h1:sImRT74obai+LNgFVxr+qNVq2yt5KEfvNxz6ZDfYWaA=
+github.com/brianstrauch/spotify v0.6.0 h1:PGD6W9lJtKd8BUpgT+s/F1k8pFMoQ8fihM4vKbYkjCI=
+github.com/brianstrauch/spotify v0.6.0/go.mod h1:KGmim5eCKSgu5y+jOrJPa8fxTFfy0GzeidodVnjGnUM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/brianstrauch/spotify v0.5.0 h1:IUEY5JPEPJJJdyVdpcH8ZzviGxI3Ra3huWPN+5
 github.com/brianstrauch/spotify v0.5.0/go.mod h1:sImRT74obai+LNgFVxr+qNVq2yt5KEfvNxz6ZDfYWaA=
 github.com/brianstrauch/spotify v0.6.0 h1:PGD6W9lJtKd8BUpgT+s/F1k8pFMoQ8fihM4vKbYkjCI=
 github.com/brianstrauch/spotify v0.6.0/go.mod h1:KGmim5eCKSgu5y+jOrJPa8fxTFfy0GzeidodVnjGnUM=
+github.com/brianstrauch/spotify v0.7.0 h1:6XvE6EocJHOgrWlL6FAPu26GhkIfLeo987Qca9q9gJs=
+github.com/brianstrauch/spotify v0.7.0/go.mod h1:KGmim5eCKSgu5y+jOrJPa8fxTFfy0GzeidodVnjGnUM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/internal/common.go
+++ b/internal/common.go
@@ -67,8 +67,8 @@ func WaitForUpdatedPlayback(api APIInterface, isUpdated func(playback *spotify.P
 	}
 }
 
-func Search(api APIInterface, query string) (*spotify.Track, error) {
-	page, err := api.Search(query, 1)
+func Search(api APIInterface, query, searchType string) (*spotify.Track, error) {
+	page, err := api.Search(query, searchType, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -4,9 +4,9 @@ const (
 	ErrAlreadyUpToDate     = "Already up to date"
 	ErrLoginFailed         = "Login failed"
 	ErrNoActiveDevice      = "Player command failed: No active device found"
-	ErrNoAlbumsFound            = "No albums found"
-	ErrNoDevicesFound           = "No devices found"
-	ErrNoPlaylistsFound         = "No playlists found"
+	ErrNoAlbumsFound       = "No albums found"
+	ErrNoDevicesFound      = "No devices found"
+	ErrNoPlaylistsFound    = "No playlists found"
 	ErrNoPrevious          = "No track before this one"
 	ErrNotLoggedIn         = `You are not logged in: Run "spotify login"`
 	ErrRestrictionViolated = "Player command failed: Restriction violated"

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -4,9 +4,9 @@ const (
 	ErrAlreadyUpToDate     = "Already up to date"
 	ErrLoginFailed         = "Login failed"
 	ErrNoActiveDevice      = "Player command failed: No active device found"
-	ErrNoAlbums            = "No albums found"
-	ErrNoDevices           = "No devices"
-	ErrNoPlaylists         = "No playlists"
+	ErrNoAlbumsFound            = "No albums found"
+	ErrNoDevicesFound           = "No devices found"
+	ErrNoPlaylistsFound         = "No playlists found"
 	ErrNoPrevious          = "No track before this one"
 	ErrNotLoggedIn         = `You are not logged in: Run "spotify login"`
 	ErrRestrictionViolated = "Player command failed: Restriction violated"

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -4,9 +4,9 @@ const (
 	ErrAlreadyUpToDate     = "Already up to date"
 	ErrLoginFailed         = "Login failed"
 	ErrNoActiveDevice      = "Player command failed: No active device found"
-	ErrNoAlbumsFound            = "No albums found"
-	ErrNoDevicesFound           = "No devices found"
-	ErrNoPlaylistsFound         = "No playlists found"
+	ErrNoAlbums            = "No albums found"
+	ErrNoDevices           = "No devices found"
+	ErrNoPlaylists         = "No playlists found"
 	ErrNoPrevious          = "No track before this one"
 	ErrNotLoggedIn         = `You are not logged in: Run "spotify login"`
 	ErrRestrictionViolated = "Player command failed: Restriction violated"

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -4,9 +4,9 @@ const (
 	ErrAlreadyUpToDate     = "Already up to date"
 	ErrLoginFailed         = "Login failed"
 	ErrNoActiveDevice      = "Player command failed: No active device found"
-	ErrNoAlbumsFound       = "No albums found"
-	ErrNoDevicesFound      = "No devices found"
-	ErrNoPlaylistsFound    = "No playlists found"
+	ErrNoAlbumsFound            = "No albums found"
+	ErrNoDevicesFound           = "No devices found"
+	ErrNoPlaylistsFound         = "No playlists found"
 	ErrNoPrevious          = "No track before this one"
 	ErrNotLoggedIn         = `You are not logged in: Run "spotify login"`
 	ErrRestrictionViolated = "Player command failed: Restriction violated"

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -4,6 +4,7 @@ const (
 	ErrAlreadyUpToDate     = "Already up to date"
 	ErrLoginFailed         = "Login failed"
 	ErrNoActiveDevice      = "Player command failed: No active device found"
+	ErrNoAlbums            = "No albums found"
 	ErrNoDevices           = "No devices"
 	ErrNoPlaylists         = "No playlists"
 	ErrNoPrevious          = "No track before this one"

--- a/internal/mock_api.go
+++ b/internal/mock_api.go
@@ -11,7 +11,7 @@ type APIInterface interface {
 
 	GetPlayback() (*spotify.Playback, error)
 	GetDevices() ([]*spotify.Device, error)
-	Play(deviceID string, uris ...string) error
+	Play(deviceID, contextURI string, uris ...string) error
 	Pause(deviceID string) error
 	SkipToNextTrack() error
 	SkipToPreviousTrack() error
@@ -19,7 +19,7 @@ type APIInterface interface {
 	Shuffle(state bool) error
 	Queue(uri string) error
 
-	Search(q string, limit int) (*spotify.Paging, error)
+	Search(q,searchType string, limit int) (*spotify.Paging, error)
 }
 
 type MockAPI struct {
@@ -58,8 +58,8 @@ func (m *MockAPI) GetDevices() ([]*spotify.Device, error) {
 	return devices.([]*spotify.Device), err
 }
 
-func (m *MockAPI) Play(deviceID string, uris ...string) error {
-	args := m.Called(deviceID, uris)
+func (m *MockAPI) Play(deviceID, contextURI string, uris ...string) error {
+	args := m.Called(deviceID, contextURI, uris)
 	return args.Error(0)
 }
 
@@ -93,8 +93,8 @@ func (m *MockAPI) Queue(uri string) error {
 	return args.Error(0)
 }
 
-func (m *MockAPI) Search(q string, limit int) (*spotify.Paging, error) {
-	args := m.Called(q, limit)
+func (m *MockAPI) Search(q, searchType string, limit int) (*spotify.Paging, error) {
+	args := m.Called(q, searchType, limit)
 
 	page := args.Get(0)
 	err := args.Error(1)

--- a/internal/mock_api.go
+++ b/internal/mock_api.go
@@ -19,7 +19,7 @@ type APIInterface interface {
 	Shuffle(state bool) error
 	Queue(uri string) error
 
-	Search(q,searchType string, limit int) (*spotify.Paging, error)
+	Search(q, searchType string, limit int) (*spotify.Paging, error)
 }
 
 type MockAPI struct {

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -28,7 +28,12 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 
-			status, err := p(api, query, deviceID)
+			playlistName, err := cmd.Flags().GetString("playlist")
+			if err != nil {
+				return err
+			}
+
+			status, err := p(api, query, playlistName, deviceID)
 			if err != nil {
 				return err
 			}
@@ -39,11 +44,12 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
+	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
 
 	return cmd
 }
 
-func p(api internal.APIInterface, query, deviceID string) (string, error) {
+func p(api internal.APIInterface, query, contextQuery, deviceID string) (string, error) {
 	if len(query) > 0 {
 		return play.Play(api, query, "", deviceID)
 	}

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -54,7 +54,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
-	cmd.Flags().String("album", "", "album name that you wish to play")
+	cmd.Flags().String("album", "", "album name")
 
 	return cmd
 }

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -54,14 +54,14 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
-	cmd.Flags().String("album", "", "album name that you wish to play'")
+	cmd.Flags().String("album", "", "album name that you wish to play")
 
 	return cmd
 }
 
 func p(api internal.APIInterface, query, contextQuery, queryType, deviceID string) (string, error) {
 	if len(query) > 0 {
-		return play.Play(api, query, "", "track", deviceID)
+		return play.Play(api, query, contextQuery, queryType, deviceID)
 	}
 
 	playback, err := api.GetPlayback()

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -2,12 +2,11 @@ package p
 
 import (
 	"errors"
+	"github.com/spf13/cobra"
 	"spotify/internal"
 	"spotify/internal/pause"
 	"spotify/internal/play"
 	"strings"
-
-	"github.com/spf13/cobra"
 )
 
 func NewCommand() *cobra.Command {
@@ -20,20 +19,30 @@ func NewCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
 			query := strings.Join(args, " ")
+			queryType := "track"
 
 			deviceID, err := cmd.Flags().GetString("device-id")
 			if err != nil {
 				return err
 			}
 
-			playlistName, err := cmd.Flags().GetString("playlist")
+			contextQuery, err := cmd.Flags().GetString("playlist")
 			if err != nil {
 				return err
 			}
 
-			status, err := p(api, query, playlistName, deviceID)
+			if contextQuery == "" {
+				contextQuery, err = cmd.Flags().GetString("album")
+				if err != nil {
+					return err
+				}
+				queryType = "album"
+			} else {
+				queryType = "playlist"
+			}
+
+			status, err := p(api, query, contextQuery, queryType, deviceID)
 			if err != nil {
 				return err
 			}
@@ -45,13 +54,14 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
+	cmd.Flags().String("album", "", "album name that you wish to play'")
 
 	return cmd
 }
 
-func p(api internal.APIInterface, query, contextQuery, deviceID string) (string, error) {
+func p(api internal.APIInterface, query, contextQuery, queryType, deviceID string) (string, error) {
 	if len(query) > 0 {
-		return play.Play(api, query, "", deviceID)
+		return play.Play(api, query, "", "track", deviceID)
 	}
 
 	playback, err := api.GetPlayback()
@@ -66,6 +76,6 @@ func p(api internal.APIInterface, query, contextQuery, deviceID string) (string,
 	if playback.IsPlaying {
 		return pause.Pause(api, deviceID)
 	} else {
-		return play.Play(api, "","", deviceID)
+		return play.Play(api, query, contextQuery, queryType, deviceID)
 	}
 }

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -45,7 +45,7 @@ func NewCommand() *cobra.Command {
 
 func p(api internal.APIInterface, query, deviceID string) (string, error) {
 	if len(query) > 0 {
-		return play.Play(api, query, deviceID)
+		return play.Play(api, query, "", deviceID)
 	}
 
 	playback, err := api.GetPlayback()
@@ -60,6 +60,6 @@ func p(api internal.APIInterface, query, deviceID string) (string, error) {
 	if playback.IsPlaying {
 		return pause.Pause(api, deviceID)
 	} else {
-		return play.Play(api, "", deviceID)
+		return play.Play(api, "","", deviceID)
 	}
 }

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -54,13 +54,14 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
-	cmd.Flags().String("album", "", "album name")
+	cmd.Flags().String("album", "", "album name that you wish to play")
 
 	return cmd
 }
 
 func p(api internal.APIInterface, query, contextQuery, queryType, deviceID string) (string, error) {
 	if len(query) > 0 {
+		return play.Play(api, query, contextQuery, queryType, deviceID)
 	}
 
 	playback, err := api.GetPlayback()

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -54,7 +54,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
-	cmd.Flags().String("album", "", "album name that you wish to play'")
+	cmd.Flags().String("album", "", "album name")
 
 	return cmd
 }

--- a/internal/p/p.go
+++ b/internal/p/p.go
@@ -60,7 +60,7 @@ func NewCommand() *cobra.Command {
 }
 
 func p(api internal.APIInterface, query, contextQuery, queryType, deviceID string) (string, error) {
-	if len(query) > 0 {
+	if len(query) > 0 || len(contextQuery) > 0 {
 		return play.Play(api, query, contextQuery, queryType, deviceID)
 	}
 

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,9 +32,9 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", []string(nil)).Return(nil)
+	api.On("Play", "", "", []string(nil)).Return(nil)
 
-	status, err := p(api, "", "")
+	status, err := p(api, "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -74,12 +74,12 @@ func TestP_Play_WithArgs(t *testing.T) {
 
 	query := "track"
 
-	api.On("Search", query, 1).Return(paging, nil)
-	api.On("Play", "", []string{uri}).Return(nil)
+	api.On("Search", query, "track", 1).Return(paging, nil)
+	api.On("Play", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
-	status, err := p(api, query, "")
+	status, err := p(api, query, "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -108,7 +108,7 @@ func TestP_Pause(t *testing.T) {
 	api.On("GetPlayback").Return(playback2, nil).Once()
 	api.On("Pause", "").Return(nil)
 
-	status, err := p(api, "", "")
+	status, err := p(api, "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r⏸\n", status)
 }
@@ -117,7 +117,7 @@ func TestP_ErrNoActiveDevice(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(nil, nil)
 
-	_, err := p(api, "", "")
+	_, err := p(api, "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrNoActiveDevice, err.Error())
 }

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,9 +32,9 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "", "", []string(nil)).Return(nil)
+	api.On("Play", "", "","",  []string(nil)).Return(nil)
 
-	status, err := p(api, "", "", "", "")
+	status, err := p(api, "", "", "","")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -75,7 +75,7 @@ func TestP_Play_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "", "", []string{uri}).Return(nil)
+	api.On("Play", "", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,9 +32,9 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "", []string(nil)).Return(nil)
+	api.On("Play", "", "","",  []string(nil)).Return(nil)
 
-	status, err := p(api, "", "", "")
+	status, err := p(api, "", "", "","")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -75,11 +75,11 @@ func TestP_Play_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "", []string{uri}).Return(nil)
+	api.On("Play", "", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
-	status, err := p(api, query, "", "")
+	status, err := p(api, query, "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -108,7 +108,7 @@ func TestP_Pause(t *testing.T) {
 	api.On("GetPlayback").Return(playback2, nil).Once()
 	api.On("Pause", "").Return(nil)
 
-	status, err := p(api, "", "", "")
+	status, err := p(api, "", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r⏸\n", status)
 }
@@ -117,7 +117,7 @@ func TestP_ErrNoActiveDevice(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(nil, nil)
 
-	_, err := p(api, "", "", "")
+	_, err := p(api, "", "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrNoActiveDevice, err.Error())
 }

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -75,7 +75,7 @@ func TestP_Play_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,7 +32,7 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "","",  []string(nil)).Return(nil)
+	api.On("Play", "", "", "",  []string(nil)).Return(nil)
 
 	status, err := p(api, "", "", "", "")
 	require.NoError(t, err)

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -75,7 +75,7 @@ func TestP_Play_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,9 +32,9 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "","",  []string(nil)).Return(nil)
+	api.On("Play", "", "", "", []string(nil)).Return(nil)
 
-	status, err := p(api, "", "", "","")
+	status, err := p(api, "", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -75,7 +75,7 @@ func TestP_Play_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -34,7 +34,7 @@ func TestP_Play(t *testing.T) {
 	api.On("GetPlayback").Return(playback2, nil).Once()
 	api.On("Play", "", "","",  []string(nil)).Return(nil)
 
-	status, err := p(api, "", "", "","")
+	status, err := p(api, "", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }

--- a/internal/p/p_test.go
+++ b/internal/p/p_test.go
@@ -32,7 +32,7 @@ func TestP_Play(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "", "",  []string(nil)).Return(nil)
+	api.On("Play", "", "", "", []string(nil)).Return(nil)
 
 	status, err := p(api, "", "", "", "")
 	require.NoError(t, err)

--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -83,7 +83,9 @@ func Play(api internal.APIInterface, query, contextQuery, queryType, deviceID st
 		}
 
 		albums := paging.Albums.Items
-		//TODO: Implement Checking of no returns of albums
+		if len(albums) == 0 {
+			return "", errors.New(internal.ErrNoAlbums)
+		}
 
 		if err := api.Play(deviceID, albums[0].URI); err != nil {
 			return "", err

--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -132,5 +132,4 @@ func Play(api internal.APIInterface, query, contextQuery, queryType, deviceID st
 	}
 
 	return status.Show(playback), nil
-
 }

--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -55,7 +55,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().String("device-id", "", "device ID from 'spotify device list'")
 	cmd.Flags().String("playlist", "", "playlist name from 'spotify playlist list'")
-	cmd.Flags().String("album", "", "album name that you wish to play'")
+	cmd.Flags().String("album", "", "album name that you wish to play")
 
 	return cmd
 }
@@ -83,9 +83,7 @@ func Play(api internal.APIInterface, query, contextQuery, queryType, deviceID st
 		}
 
 		albums := paging.Albums.Items
-		if len(albums) > 0 {
-			return "", errors.New(internal.ErrNoAlbums)
-		}
+		//TODO: Implement Checking of no returns of albums
 
 		if err := api.Play(deviceID, albums[0].URI); err != nil {
 			return "", err

--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -130,4 +130,5 @@ func Play(api internal.APIInterface, query, contextQuery, queryType, deviceID st
 	}
 
 	return status.Show(playback), nil
+
 }

--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -72,6 +72,7 @@ func Play(api internal.APIInterface, query, contextQuery, queryType, deviceID st
 
 	switch queryType {
 	case "album":
+
 		api, err := internal.Authenticate()
 		if err != nil {
 			return "", err

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -33,7 +33,7 @@ func TestPlay(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Once()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", "", "", []string(nil)).Return(nil)
+	api.On("Play", "","","", []string(nil)).Return(nil)
 
 	status, err := Play(api, "", "", "", "")
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestPlay_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "", "", []string{uri}).Return(nil)
+	api.On("Play", "", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
@@ -88,7 +88,7 @@ func TestPlay_WithArgs(t *testing.T) {
 func TestPlay_ErrAlreadyPlaying(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(new(spotify.Playback), nil)
-	api.On("Play", "", "", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
+	api.On("Play", "", "","", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
 
 	_, err := Play(api, "", "", "", "")
 	require.Error(t, err)

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -76,7 +76,7 @@ func TestPlay_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -76,7 +76,7 @@ func TestPlay_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -88,7 +88,7 @@ func TestPlay_WithArgs(t *testing.T) {
 func TestPlay_ErrAlreadyPlaying(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(new(spotify.Playback), nil)
-	api.On("Play", "", "","", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
+	api.On("Play", "", "", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
 
 	_, err := Play(api, "", "", "", "")
 	require.Error(t, err)

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -33,9 +33,9 @@ func TestPlay(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Once()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "", []string(nil)).Return(nil)
+	api.On("Play", "","", []string(nil)).Return(nil)
 
-	status, err := Play(api, "", "")
+	status, err := Play(api, "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -75,12 +75,12 @@ func TestPlay_WithArgs(t *testing.T) {
 
 	query := "track"
 
-	api.On("Search", query, 1).Return(paging, nil)
-	api.On("Play", "", []string{uri}).Return(nil)
+	api.On("Search", query, "track", 1).Return(paging, nil)
+	api.On("Play", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
-	status, err := Play(api, query, "")
+	status, err := Play(api, query, "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -88,9 +88,9 @@ func TestPlay_WithArgs(t *testing.T) {
 func TestPlay_ErrAlreadyPlaying(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(new(spotify.Playback), nil)
-	api.On("Play", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
+	api.On("Play", "", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
 
-	_, err := Play(api, "", "")
+	_, err := Play(api, "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrRestrictionViolated, err.Error())
 }
@@ -99,7 +99,7 @@ func TestPlay_ErrNoActiveDevice(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(nil, nil)
 
-	_, err := Play(api, "", "")
+	_, err := Play(api, "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrNoActiveDevice, err.Error())
 }

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -33,7 +33,7 @@ func TestPlay(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Once()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "","","", []string(nil)).Return(nil)
+	api.On("Play", "", "", "", []string(nil)).Return(nil)
 
 	status, err := Play(api, "", "", "", "")
 	require.NoError(t, err)

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -33,9 +33,9 @@ func TestPlay(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Once()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "","", []string(nil)).Return(nil)
+	api.On("Play", "","","", []string(nil)).Return(nil)
 
-	status, err := Play(api, "", "", "")
+	status, err := Play(api, "", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -76,11 +76,11 @@ func TestPlay_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "", []string{uri}).Return(nil)
+	api.On("Play", "", "","", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
-	status, err := Play(api, query, "", "")
+	status, err := Play(api, query, "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, "   Track\r🎵\n   Artist\r🎤\n   0:00 [                ] 0:01\r▶️\n", status)
 }
@@ -88,9 +88,9 @@ func TestPlay_WithArgs(t *testing.T) {
 func TestPlay_ErrAlreadyPlaying(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(new(spotify.Playback), nil)
-	api.On("Play", "", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
+	api.On("Play", "", "","", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
 
-	_, err := Play(api, "", "", "")
+	_, err := Play(api, "", "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrRestrictionViolated, err.Error())
 }
@@ -99,7 +99,7 @@ func TestPlay_ErrNoActiveDevice(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(nil, nil)
 
-	_, err := Play(api, "", "", "")
+	_, err := Play(api, "", "", "", "")
 	require.Error(t, err)
 	require.Equal(t, internal.ErrNoActiveDevice, err.Error())
 }

--- a/internal/play/play_test.go
+++ b/internal/play/play_test.go
@@ -33,7 +33,7 @@ func TestPlay(t *testing.T) {
 
 	api.On("GetPlayback").Return(playback1, nil).Once()
 	api.On("GetPlayback").Return(playback2, nil).Once()
-	api.On("Play", "","","", []string(nil)).Return(nil)
+	api.On("Play", "", "", "", []string(nil)).Return(nil)
 
 	status, err := Play(api, "", "", "", "")
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestPlay_WithArgs(t *testing.T) {
 	query := "track"
 
 	api.On("Search", query, "track", 1).Return(paging, nil)
-	api.On("Play", "", "","", []string{uri}).Return(nil)
+	api.On("Play", "", "", "", []string{uri}).Return(nil)
 	api.On("GetPlayback").Return(playback1, nil).Twice()
 	api.On("GetPlayback").Return(playback2, nil).Once()
 
@@ -88,7 +88,7 @@ func TestPlay_WithArgs(t *testing.T) {
 func TestPlay_ErrAlreadyPlaying(t *testing.T) {
 	api := new(internal.MockAPI)
 	api.On("GetPlayback").Return(new(spotify.Playback), nil)
-	api.On("Play", "", "","", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
+	api.On("Play", "", "", "", []string(nil)).Return(errors.New(internal.ErrRestrictionViolated))
 
 	_, err := Play(api, "", "", "", "")
 	require.Error(t, err)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -35,7 +35,7 @@ func NewCommand() *cobra.Command {
 }
 
 func Queue(api internal.APIInterface, query string) (string, error) {
-	track, err := internal.Search(api, query)
+	track, err := internal.Search(api, query, "track")
 	if err != nil {
 		return "", err
 	}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -26,7 +26,7 @@ func TestQueue(t *testing.T) {
 
 	query := "track"
 
-	api.On("Search", query, 1).Return(paging, nil).Once()
+	api.On("Search", query, "track", 1).Return(paging, nil).Once()
 	api.On("Queue", uri).Return(nil)
 
 	output, err := Queue(api, query)


### PR DESCRIPTION
Fixes issue #27 

Upgraded root spotify module from v0.5.0 => v0.6.0.
Added --playlist flag to the play function that takes a playlist name and plays it.

Tests have been updated to reflect upgrade from spotify v0.5.0 -> v0.6.0
New tests required for additional features.