### PR TITLE
Version auto-updating. Issue #30

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"spotify/internal/back"
 	"spotify/internal/device"
 	"spotify/internal/login"
@@ -33,7 +34,7 @@ func main() {
 	root := &cobra.Command{
 		Use:               "spotify",
 		Short:             "Spotify for the terminal 🎵",
-		Version:           "1.9.2",
+		Version:           buildVersion(version, commit, date),
 		PersistentPreRunE: promptUpdate,
 	}
 
@@ -57,6 +58,24 @@ func main() {
 	root.SetHelpCommand(&cobra.Command{Hidden: true})
 
 	_ = root.Execute()
+}
+
+// Sets ldflags by goreleaser https://goreleaser.com/customization/build/ (default values)
+var (
+	version = "dev"
+	commit  string
+	date    string
+)
+
+func buildVersion(version, commit, date string) string {
+	result := version
+	if commit != "" {
+		result = fmt.Sprintf("%s\ncommit: %s", result, commit)
+	}
+	if date != "" {
+		result = fmt.Sprintf("%s\nbuilt at: %s", result, date)
+	}
+	return result
 }
 
 func promptUpdate(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
Resolve issue https://github.com/brianstrauch/spotify-cli/issues/30
Add **ldflags** for sets application version (https://goreleaser.com/customization/build/)

example for dev environment:
```
$ goreleaser release --snapshot --skip-publish --rm-dist
$ ./spotify-cli --version

spotify version v1.9.2-SNAPSHOT-0ebcff2
commit: 0ebcff245e7d750ead4a11e0b1ce50f9c9beb40a
built at: 2021-07-20T20:11:53Z
```

How to use. (example: https://goreleaser.com/quick-start/)
example:
- just create new tag: `git tag -a v1.9.3 -m "new best features"`
- then push: `git push origin v1.9.3`
And goreleaser **auto sets** version for app.